### PR TITLE
Support Descriptive List 

### DIFF
--- a/src/types/greaterelements.jl
+++ b/src/types/greaterelements.jl
@@ -50,6 +50,9 @@ end
 mutable struct OrderedList <: List
     items::Vector{Item}
 end
+mutable struct DescriptiveList <: List
+    items::Vector{Item}
+end
 
 mutable struct PropertyDrawer <: GreaterElement
     contents::Vector{NodeProperty}


### PR DESCRIPTION
Adds DescriptiveList type and corresponding parser support.

See <https://orgmode.org/worg/dev/org-syntax.html#Plain_Lists_and_Items>

Also changes list parser to no longer join incompatible items. E.g.
``` julila
org"
- item1
1. item2
"
```
will result in two lists instead of one.