### PR TITLE
Support for LaTeXFragment delimited by `$...$`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Org"
 uuid = "587fedb0-ad84-11e9-2bd6-d15ea4be1f9e"
 authors = ["TEC <tec@tecosaur.com> and contributors"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/parse/consumers.jl
+++ b/src/parse/consumers.jl
@@ -615,7 +615,7 @@ function consume(::Type{TextPlain}, content::SubString{String})
             return if i > 1 textobjupto(li) end
         elseif c in ('*', '/', '+', '_', '~', '=') && (spc(lc) || lc in ('-', '(', '{', '\'', '"')) && !spc(nc) # markup
             return if cc > 2 textobjupto(li) end
-        elseif c == '\\' && !spc(nc) # entities & latex & line break
+        elseif (c == '\\' || c == '$') && !spc(nc) # entities & latex & line break
             return if i > 1 textobjupto(li) end
         elseif c == '<' # angle links, targets, active timestamps
             return if i > 1 textobjupto(li) end

--- a/src/parse/interpret.jl
+++ b/src/parse/interpret.jl
@@ -288,8 +288,13 @@ function LaTeXFragment(components::Vector{Union{Nothing, SubString{String}}})
     if isnothing(delimitedform)
         LaTeXFragment(command::SubString{String}, nothing)
     else
-        LaTeXFragment(delimitedform[3:end-2],
+        if delimitedform[1] == '$'
+            LaTeXFragment(delimitedform[2:end-1],
+                      (delimitedform[1:1], delimitedform[end:end]))
+        else
+            LaTeXFragment(delimitedform[3:end-2],
                       (delimitedform[1:2], delimitedform[end-1:end]))
+        end
     end
 end
 

--- a/src/parse/matchers.jl
+++ b/src/parse/matchers.jl
@@ -77,6 +77,7 @@ const org_object_matchers =
         '{' => [Macro],
         '<' => [RadioTarget, Target, AngleLink, Timestamp],
         '\\' => [LineBreak, Entity, LaTeXFragment],
+        '$' => [LaTeXFragment],
         '*' => [TextMarkup],
         '/' => [TextMarkup],
         '_' => [TextMarkup],
@@ -93,7 +94,7 @@ const org_object_fallbacks =
 
 # Entity has a custom consumer
 
-@inline orgmatcher(::Type{LaTeXFragment}) = r"^(\\[A-Za-z]+(?:{[^{}\n]*}|\[[^][{}\n]*\])*)|(\\\(.*?\\\)|\\\[.*?\\\])"
+@inline orgmatcher(::Type{LaTeXFragment}) = r"^(\\[A-Za-z]+(?:{[^{}\n]*}|\[[^][{}\n]*\])*)|(\\\(.*?\\\)|\\\[.*?\\\]|\$.*?\$)"
 @inline orgmatcher(::Type{ExportSnippet}) = r"^\@\@([A-Za-z0-9-]+):(.*?)\@\@"
 # FootnoteReference has a dedicated consumer
 @inline orgmatcher(::Type{InlineBabelCall}) = r"^call_([^()\n]+?)(?:(\[[^]\n]+\]))?\(([^)\n]*)\)(?:(\[[^]\n]+\]))?"


### PR DESCRIPTION
As the title says:) `$...$` are supported by default in Org, so it seems like something that would be useful to support in Org.jl too.

I noticed there aren't any tests, so I didn't add any; happy to add some if desired!