### PR TITLE
Fix nested markup and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Manifest.toml
+*.cov

--- a/src/parse/consumers.jl
+++ b/src/parse/consumers.jl
@@ -541,7 +541,8 @@ function consume(::Type{TextMarkup}, text::SubString{String})
         if text isa SubString
             text.offset == 0 ||
             text.string[prevind(text.string, 1+text.offset)] in
-            ('-', '(', '{', ''', '"', ' ', '\t', '\n', '\u2000':'\u200c'...) || # pre condition
+            ('*', '/', '+', '_', '-', '(', '{', ''',
+             '"', ' ', '\t', '\n', '\u2000':'\u200c'...) || # pre condition
             (text.string[prevind(text.string, 1+text.offset)] == '[' &&
             text.string[prevind(text.string, text.offset)] == ']') # link description
         else

--- a/src/types/objects.jl
+++ b/src/types/objects.jl
@@ -231,10 +231,10 @@ mutable struct TextMarkup{C <: Union{Vector{Object}, SubString{String}}} <: Obje
     contents::C
 end
 function TextMarkup(formatting::Symbol, contents::String)
-    if formatting in ('=', '~')
+    if formatting in (:code, :verbatim)
         TextMarkup(formatting, SubString(contents))
     else
-        TextMarkup(formatting, TextPlain(contents))
+        TextMarkup(formatting, Object[TextPlain(contents)])
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,26 @@
 using Org
 using Test
+import Org: Object, Paragraph, Section, TextPlain, TextMarkup
 
-@testset "Org.jl" begin
-    # Write your tests here.
+@testset "Parsing tests" begin
+    # wraps obj in a single paragraph doc
+    para(x::Object) = OrgDoc([Section([Paragraph([x])])])
+    testcases = [
+        org"plain-text" => para(TextPlain("plain-text")),
+        # single TextMarkup
+        org"*bold-text*" => para(TextMarkup(:bold, "bold-text")),
+        org"/it-text/" => para(TextMarkup(:italic, "it-text")),
+        org"+striked-text+" => para(TextMarkup(:strikethrough, "striked-text")),
+        org"_underlined-text_" => para(TextMarkup(:underline, "underlined-text")),
+        org"=verbatim-text=" => para(TextMarkup(:verbatim, "verbatim-text")),
+        org"~code-text~" => para(TextMarkup(:code, "code-text")),
+        # nested TextMarkup (~ and = must preserve contents as-is)
+        org"*/bold-it/*" => para(TextMarkup(:bold, Object[TextMarkup(:italic, "bold-it")])),
+        org"/*it-bold*/" => para(TextMarkup(:italic, Object[TextMarkup(:bold, "it-bold")])),
+        org"~*bold-code*~" => para(TextMarkup(:code, "*bold-code*")),
+        org"=*bold-verbatim*=" => para(TextMarkup(:verbatim, "*bold-verbatim*"))
+    ]
+    for (actual, expected) in testcases
+        @test actual == expected
+    end
 end


### PR DESCRIPTION
The main purpose of this PR is to add some unit tests. Not a lot (~8% coverage). Along the way, I discovered a couple of bugs.

Firstly, nested inline markup did not parse as expected. Evaluating `parsetree(org"*/text/*")` returned the following:

```
Org Parse Tree
    Section
        Paragraph
            TextBold
                TextPlain "/text/"
```

It now returns the following:

```
Org Parse Tree
    Section
        Paragraph
            TextBold
                TextItalic
                    TextPlain "text"
```

Secondly, the `TextMarkup(::Symbol,::String)` constructor was functionally broken. Granted, this constructor isn't documented.